### PR TITLE
add support for using jsonpointer ony any struct/slice

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -1,0 +1,114 @@
+// Package jsonpointer implements RFC6901 JSON Pointers
+package jsonpointer
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// Get the value at the specified path.
+func Reflect(o interface{}, path string) interface{} {
+	if path == "" {
+		return o
+	}
+
+	parts := strings.Split(path[1:], "/")
+	var rv interface{} = o
+
+OUTER:
+	for _, p := range parts {
+		val := reflect.ValueOf(rv)
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+
+		if val.Kind() == reflect.Struct {
+			if strings.Contains(p, "~") {
+				p = strings.Replace(p, "~1", "/", -1)
+				p = strings.Replace(p, "~0", "~", -1)
+			}
+
+			// first look to see if path matches JSON tag name
+			typ := val.Type()
+			for i := 0; i < typ.NumField(); i++ {
+				sf := typ.Field(i)
+				tag := sf.Tag.Get("json")
+				name := parseJSONTagName(tag)
+				if name == p {
+					rv = val.Field(i).Interface()
+					continue OUTER
+				}
+			}
+
+			// no JSON tag name matched, look for direct field match
+			field := val.FieldByName(p)
+			if field.IsValid() {
+				rv = field.Interface()
+			} else {
+				return nil
+			}
+		} else if val.Kind() == reflect.Slice {
+			i, err := strconv.Atoi(p)
+			if err == nil && i < val.Len() {
+				field := val.Index(i)
+				rv = field.Interface()
+			} else {
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+
+	return rv
+}
+
+func ReflectListPointers(o interface{}) ([]string, error) {
+	return reflectListPointersRecursive(o, ""), nil
+}
+
+func reflectListPointersRecursive(o interface{}, prefix string) []string {
+	rv := []string{prefix + ""}
+
+	val := reflect.ValueOf(o)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	if val.Kind() == reflect.Struct {
+
+		typ := val.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			child := val.Field(i).Interface()
+			sf := typ.Field(i)
+			tag := sf.Tag.Get("json")
+			name := parseJSONTagName(tag)
+			if name != "" {
+				// use the tag name
+				childReults := reflectListPointersRecursive(child, prefix+encodePointer([]string{name}))
+				rv = append(rv, childReults...)
+			} else {
+				// use the original field name
+				childResults := reflectListPointersRecursive(child, prefix+encodePointer([]string{sf.Name}))
+				rv = append(rv, childResults...)
+			}
+		}
+
+	} else if val.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			child := val.Index(i).Interface()
+			childResults := reflectListPointersRecursive(child, prefix+encodePointer([]string{strconv.Itoa(i)}))
+			rv = append(rv, childResults...)
+		}
+	}
+
+	return rv
+}
+
+func parseJSONTagName(tag string) string {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx]
+	}
+	return tag
+}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,0 +1,123 @@
+package jsonpointer
+
+import (
+	"reflect"
+	"testing"
+)
+
+type address struct {
+	Street string `json:"street"`
+	Zip    string
+}
+
+type person struct {
+	Name               string `json:"name,omitempty"`
+	Twitter            string
+	Aliases            []string   `json:"aliases"`
+	Addresses          []*address `json:"addresses"`
+	NameTildeContained string     `json:"name~contained"`
+	NameSlashContained string     `json:"name/contained"`
+}
+
+var input = &person{
+	Name:    "marty",
+	Twitter: "mschoch",
+	Aliases: []string{
+		"jabroni",
+		"beer",
+	},
+	Addresses: []*address{
+		&address{
+			Street: "123 Sesame St.",
+			Zip:    "99099",
+		},
+	},
+	NameTildeContained: "yessir",
+	NameSlashContained: "nosir",
+}
+
+func TestReflectListPointers(t *testing.T) {
+	pointers, err := ReflectListPointers(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := []string{"", "/name", "/Twitter", "/aliases", "/aliases/0", "/aliases/1", "/addresses", "/addresses/0", "/addresses/0/street", "/addresses/0/Zip", "/name~0contained", "/name~1contained"}
+	if !reflect.DeepEqual(pointers, expect) {
+		t.Fatalf("expected %#v, got %#v", expect, pointers)
+	}
+}
+
+func TestReflectNonObjectOrSlice(t *testing.T) {
+	got := Reflect(36, "/test")
+	if got != nil {
+		t.Errorf("expected nil, got %#v", got)
+	}
+}
+
+func TestReflect(t *testing.T) {
+
+	tests := []struct {
+		path string
+		exp  interface{}
+	}{
+		{
+			path: "",
+			exp:  input,
+		},
+		{
+			path: "/name",
+			exp:  "marty",
+		},
+		{
+			path: "/Name",
+			exp:  "marty",
+		},
+		{
+			path: "/Twitter",
+			exp:  "mschoch",
+		},
+		{
+			path: "/aliases/0",
+			exp:  "jabroni",
+		},
+		{
+			path: "/Aliases/0",
+			exp:  "jabroni",
+		},
+		{
+			path: "/addresses/0/street",
+			exp:  "123 Sesame St.",
+		},
+		{
+			path: "/addresses/4/street",
+			exp:  nil,
+		},
+		{
+			path: "/doesntexist",
+			exp:  nil,
+		},
+		{
+			path: "/does/not/exit",
+			exp:  nil,
+		},
+		{
+			path: "/doesntexist/7",
+			exp:  nil,
+		},
+		{
+			path: "/name~0contained",
+			exp:  "yessir",
+		},
+		{
+			path: "/name~1contained",
+			exp:  "nosir",
+		},
+	}
+
+	for _, test := range tests {
+		output := Reflect(input, test.path)
+		if !reflect.DeepEqual(output, test.exp) {
+			t.Errorf("Expected %#v, got %#v", test.exp, output)
+		}
+	}
+}


### PR DESCRIPTION
this implementation uses reflection to interrogate/traverse objects
jsonpointer field names can refer to exaxt (exported) field names
or they can also refer to JSON field names specified in struct tags

For example, consider the struct:

type Person struct {
    Name string `json:"name"`
}

You can access the Name field using either "/Name" or "/name".
