### PR TITLE
bson.M support

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,9 +1,18 @@
 package jsonpointer
 
 import (
+	"gopkg.in/mgo.v2/bson"
 	"strconv"
 	"strings"
 )
+
+func handleTilde(p string) string {
+	if strings.Contains(p, "~") {
+		p = strings.Replace(p, "~1", "/", -1)
+		p = strings.Replace(p, "~0", "~", -1)
+	}
+	return p
+}
 
 // Get the value at the specified path.
 func Get(m map[string]interface{}, path string) interface{} {
@@ -15,12 +24,13 @@ func Get(m map[string]interface{}, path string) interface{} {
 	var rv interface{} = m
 
 	for _, p := range parts {
+
 		switch v := rv.(type) {
 		case map[string]interface{}:
-			if strings.Contains(p, "~") {
-				p = strings.Replace(p, "~1", "/", -1)
-				p = strings.Replace(p, "~0", "~", -1)
-			}
+			handleTilde(p)
+			rv = v[p]
+		case bson.M:
+			handleTilde(p)
 			rv = v[p]
 		case []interface{}:
 			i, err := strconv.Atoi(p)


### PR DESCRIPTION
Hey there, perhaps you can craft this better, but this tests well against an `mgo` query `bson.M` result along the lines of

```go
func getUser(id string) (user bson.M) {
        _ = getDB().C("users").Find(bson.M{"_id": id}).One(&user)
        return
}
```

This takes care of the nulls I was getting when the switch type was falling through to default instead of being grabbed by the map. I tried just adding with `,` to the first case but no joy.